### PR TITLE
修复 notify-send 命令因参数引用不当导致的 "Invalid number of options" 错误

### DIFF
--- a/song.sh
+++ b/song.sh
@@ -78,7 +78,7 @@ notifySongInfo(){
   # 下载图片
   curl -s -L $icon -o "$songIcons/$songId.$iconSu"
   # 弹出提示框
-  notify-send -h string:x-dunst-stack-tag:music "$title-$artist" $album -t 800 --icon "$songIcons/$songId.$iconSu"
+  notify-send -h string:x-dunst-stack-tag:music "$title-$artist" "$album" -t 800 --icon "$songIcons/$songId.$iconSu"
 }
 
 title(){


### PR DESCRIPTION
给`$album`变量添加引号,确保了即使变量内容包含空格,它们也会被整体视为单个参数传递给 `notify-send` 命令